### PR TITLE
fix: replace DenseMAETrainer with HiEndMAETrainer in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
     for k,v in sorted(vars(args).items()):
         print(k,'=',v)
     seed_torch(args.seed)
-    trainer = DenseMAETrainer(args=args)
+    trainer = HiEndMAETrainer(args=args)
 
     trainer.run()
     


### PR DESCRIPTION
The original `DenseMAETrainer` was not found in the repo, it should be `HiEndMAETrainer` according to the import section in `main.py`, line 59.